### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Villoh/portfolio-backend/security/code-scanning/2](https://github.com/Villoh/portfolio-backend/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is sufficient for checking out the code and setting up dependencies.
- `contents: write` is required for uploading artifacts (`actions/upload-artifact`).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `test` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
