### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Villoh/portfolio-backend/security/code-scanning/1](https://github.com/Villoh/portfolio-backend/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it primarily involves checking out code and building the application, so `contents: read` should suffice. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
